### PR TITLE
Fix dependencies, Add CI

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,6 +1,6 @@
 name: PlatformIO CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -4,14 +4,10 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        example: [examples/tact_arduino_uno.cpp, examples/tact_mbed.cpp]
-        board: [uno, nucleo_f446re]
-        framework: [arduino, mbed]
 
     steps:
       - uses: actions/checkout@v3
@@ -28,6 +24,6 @@ jobs:
         run: pip install --upgrade platformio
 
       - name: Run PlatformIO
-        run: pio ci --lib="." --board=${{ matrix.board }} -O framework=${{ matrix.framework }}
-        env:
-          PLATFORMIO_CI_SRC: ${{ matrix.example }}
+        run: |
+          pio ci --lib="." --board=uno examples/tact_arduino_uno.cpp
+          pio ci --lib="." --board=nucleo_f446re -O framework=mbed examples/tact_mbed.cpp

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
 
-      - name: Run PlatformIO
-        run: |
-          pio ci --lib="." --board=uno examples/tact_arduino_uno.cpp
-          pio ci --lib="." --board=nucleo_f446re -O framework=mbed examples/tact_mbed.cpp
+      - name: Build tact_arduino_uno example
+        run: pio ci --lib="." --board=uno examples/tact_arduino_uno.cpp
+      
+      - name: Build examples/tact_mbed example
+        run: pio ci --lib="." --board=disco_f469ni -O framework=mbed examples/tact_mbed.cpp

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,0 +1,33 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        example: [examples/tact_arduino_uno.cpp, examples/tact_mbed.cpp]
+        board: [uno, nucleo_f446re]
+        framework: [arduino, mbed]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Run PlatformIO
+        run: pio ci --lib="." --board=${{ matrix.board }} -O framework=${{ matrix.framework }}
+        env:
+          PLATFORMIO_CI_SRC: ${{ matrix.example }}

--- a/library.json
+++ b/library.json
@@ -17,8 +17,5 @@
       "maintainer": true
     }
   ],
-  "license": "Apache",
-  "dependencies": {
-    "ownername/print": "~1.3.0"
-  }
+  "license": "Apache"
 }


### PR DESCRIPTION
* Removes unneeded dependency `"ownername/print": "~1.3.0"` which doesn't even exist (likely [copy-pasted from example](https://docs.platformio.org/en/latest/librarymanager/creating.html#manifest))
* Add Github Actions file for Continuous Integration (CI), builds both examples for an example board, see e.g. https://github.com/maxgerhardt/tact/actions/runs/3893732964